### PR TITLE
🐛 fix: remove escape character

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,8 +14,14 @@ const colorCodes = {
     '[39m': '</span>',
 };
 
+const replaceEscapeCharacter = (string) => {
+    return string.replace(/[\u001b]+/g, '');
+}
+
 // ANSI escape code to HTML
 const replaceCode = (node) => {
+    node.innerHTML = replaceEscapeCharacter(node.innerHTML);
+
     node.innerHTML = node.innerHTML.replace(pattern, (code) => {
         if (!colorCodes[code]) {
             return code;


### PR DESCRIPTION
This PR fixes the "white square issue", where the HTML won't handle the escape character and show a square instead.

https://github.com/Falydoor/aws-cloudwatch-ansi-colors/issues/2